### PR TITLE
feat: Add getPrivateKey method for key signer

### DIFF
--- a/src/wallet/key/key.test.ts
+++ b/src/wallet/key/key.test.ts
@@ -29,6 +29,14 @@ describe('Private Key Signer', () => {
     expect(publicKey).toHaveLength(65);
   });
 
+  test('getPrivateKey', async () => {
+    const signer: KeySigner = await generateRandomKeySigner();
+    const privateKey: Uint8Array = await signer.getPrivateKey();
+
+    expect(privateKey).not.toBeNull();
+    expect(privateKey).toHaveLength(32);
+  });
+
   test('signData', async () => {
     const rawData: Uint8Array = stringToUTF8('random raw data');
     const signer: KeySigner = await generateRandomKeySigner();

--- a/src/wallet/key/key.ts
+++ b/src/wallet/key/key.ts
@@ -31,6 +31,10 @@ export class KeySigner implements Signer {
     return this.publicKey;
   };
 
+  getPrivateKey = async (): Promise<Uint8Array> => {
+    return this.privateKey;
+  };
+
   signData = async (data: Uint8Array): Promise<Uint8Array> => {
     const signature = await Secp256k1.createSignature(
       sha256(data),

--- a/src/wallet/ledger/ledger.ts
+++ b/src/wallet/ledger/ledger.ts
@@ -45,7 +45,7 @@ export class LedgerSigner implements Signer {
   };
 
   getPrivateKey = async (): Promise<Uint8Array> => {
-    throw new Error('Ledger does not support private key');
+    throw new Error('Ledger does not support private key exports');
   };
 
   signData = async (data: Uint8Array): Promise<Uint8Array> => {

--- a/src/wallet/ledger/ledger.ts
+++ b/src/wallet/ledger/ledger.ts
@@ -44,6 +44,10 @@ export class LedgerSigner implements Signer {
     return this.connector.getPubkey(this.hdPath);
   };
 
+  getPrivateKey = async (): Promise<Uint8Array> => {
+    throw new Error('Ledger does not support private key');
+  };
+
   signData = async (data: Uint8Array): Promise<Uint8Array> => {
     if (!this.connector) {
       throw new Error('Ledger not connected');

--- a/src/wallet/signer.ts
+++ b/src/wallet/signer.ts
@@ -14,6 +14,11 @@ export interface Signer {
   getPublicKey(): Promise<Uint8Array>;
 
   /**
+   * Returns the signer's Secp256k1-compressed private key
+   */
+  getPrivateKey(): Promise<Uint8Array>;
+
+  /**
    * Generates a data signature for arbitrary input
    * @param {Uint8Array} data the data to be signed
    */

--- a/src/wallet/signer.ts
+++ b/src/wallet/signer.ts
@@ -14,7 +14,7 @@ export interface Signer {
   getPublicKey(): Promise<Uint8Array>;
 
   /**
-   * Returns the signer's Secp256k1-compressed private key
+   * Returns the signer's actual raw private key
    */
   getPrivateKey(): Promise<Uint8Array>;
 


### PR DESCRIPTION
The Adena wallet has a UI that shows the private key.
For this, we need a method to return the private key from `wallet.signer`.

Thanks.