### PR TITLE
feat: Add the option to set the prefix of an address.

### DIFF
--- a/src/wallet/key/key.ts
+++ b/src/wallet/key/key.ts
@@ -1,7 +1,7 @@
 import { Signer } from '../signer';
 import { encodeSecp256k1Pubkey, pubkeyToAddress } from '@cosmjs/amino';
 import { Secp256k1, Secp256k1Signature, sha256 } from '@cosmjs/crypto';
-import { addressPrefix } from '../utility';
+import { defaultAddressPrefix } from '../utility';
 
 /**
  * KeySigner implements the logic for the private key signer
@@ -9,21 +9,28 @@ import { addressPrefix } from '../utility';
 export class KeySigner implements Signer {
   private readonly privateKey: Uint8Array; // the raw private key
   private readonly publicKey: Uint8Array; // the compressed public key
+  private readonly addressPrefix: string; // the address prefix
 
   /**
    * Creates a new {@link KeySigner} instance
    * @param {Uint8Array} privateKey the raw Secp256k1 private key
    * @param {Uint8Array} publicKey the raw Secp256k1 public key
+   * @param {string} addressPrefix the address prefix
    */
-  constructor(privateKey: Uint8Array, publicKey: Uint8Array) {
+  constructor(
+    privateKey: Uint8Array,
+    publicKey: Uint8Array,
+    addressPrefix: string = defaultAddressPrefix
+  ) {
     this.privateKey = privateKey;
     this.publicKey = publicKey;
+    this.addressPrefix = addressPrefix;
   }
 
   getAddress = async (): Promise<string> => {
     return pubkeyToAddress(
       encodeSecp256k1Pubkey(Secp256k1.compressPubkey(this.publicKey)),
-      addressPrefix
+      this.addressPrefix
     );
   };
 

--- a/src/wallet/ledger/ledger.ts
+++ b/src/wallet/ledger/ledger.ts
@@ -1,6 +1,6 @@
 import { Signer } from '../signer';
 import { LedgerConnector } from '@cosmjs/ledger-amino';
-import { addressPrefix, generateHDPath } from '../utility';
+import { defaultAddressPrefix, generateHDPath } from '../utility';
 import { HdPath, Secp256k1, Secp256k1Signature, sha256 } from '@cosmjs/crypto';
 import { encodeSecp256k1Pubkey, pubkeyToAddress } from '@cosmjs/amino';
 
@@ -10,15 +10,22 @@ import { encodeSecp256k1Pubkey, pubkeyToAddress } from '@cosmjs/amino';
 export class LedgerSigner implements Signer {
   private readonly connector: LedgerConnector;
   private readonly hdPath: HdPath;
+  private readonly addressPrefix: string;
 
   /**
    * Creates a new Ledger device signer instance
    * @param {LedgerConnector} connector the Ledger connector
    * @param {number} accountIndex the desired account index
+   * @param {string} addressPrefix the address prefix
    */
-  constructor(connector: LedgerConnector, accountIndex: number) {
+  constructor(
+    connector: LedgerConnector,
+    accountIndex: number,
+    addressPrefix: string = defaultAddressPrefix
+  ) {
     this.connector = connector;
     this.hdPath = generateHDPath(accountIndex);
+    this.addressPrefix = addressPrefix;
   }
 
   getAddress = async (): Promise<string> => {
@@ -32,7 +39,7 @@ export class LedgerSigner implements Signer {
 
     return pubkeyToAddress(
       encodeSecp256k1Pubkey(compressedPubKey),
-      addressPrefix
+      this.addressPrefix
     );
   };
 

--- a/src/wallet/utility/utility.ts
+++ b/src/wallet/utility/utility.ts
@@ -72,7 +72,7 @@ export const generateKeyPair = async (
 };
 
 // Address prefix for TM2 networks
-export const addressPrefix = 'g';
+export const defaultAddressPrefix = 'g';
 
 /**
  * Encodes a string into a Uint8Array

--- a/src/wallet/wallet.test.ts
+++ b/src/wallet/wallet.test.ts
@@ -2,7 +2,11 @@ import { JSONRPCProvider, Status } from '../provider';
 import { mock } from 'jest-mock-extended';
 import { Wallet } from './wallet';
 import { EnglishMnemonic, Secp256k1 } from '@cosmjs/crypto';
-import { addressPrefix, generateEntropy, generateKeyPair } from './utility';
+import {
+  defaultAddressPrefix,
+  generateEntropy,
+  generateKeyPair,
+} from './utility';
 import { entropyToMnemonic } from '@cosmjs/crypto/build/bip39';
 import { KeySigner } from './key';
 import { Signer } from './signer';
@@ -44,7 +48,7 @@ describe('Wallet', () => {
     const address: string = await wallet.getAddress();
 
     expect(address).toBe(
-      `${addressPrefix}1vcjvkjdvckprkcpm7l44plrtg83asfu9geaz90`
+      `${defaultAddressPrefix}1vcjvkjdvckprkcpm7l44plrtg83asfu9geaz90`
     );
   });
 

--- a/src/wallet/wallet.ts
+++ b/src/wallet/wallet.ts
@@ -32,7 +32,9 @@ export class Wallet {
   /**
    * Generates a private key-based wallet, using a random seed
    */
-  static createRandom = async (): Promise<Wallet> => {
+  static createRandom = async (options?: {
+    addressPrefix?: string;
+  }): Promise<Wallet> => {
     const { publicKey, privateKey } = await generateKeyPair(
       entropyToMnemonic(generateEntropy()),
       0
@@ -42,7 +44,8 @@ export class Wallet {
     const wallet: Wallet = new Wallet();
     wallet.signer = new KeySigner(
       privateKey,
-      Secp256k1.compressPubkey(publicKey)
+      Secp256k1.compressPubkey(publicKey),
+      options?.addressPrefix
     );
 
     return wallet;
@@ -55,18 +58,22 @@ export class Wallet {
    */
   static fromMnemonic = async (
     mnemonic: string,
-    accountIndex?: number
+    options?: {
+      accountIndex?: number;
+      addressPrefix?: string;
+    }
   ): Promise<Wallet> => {
     const { publicKey, privateKey } = await generateKeyPair(
       mnemonic,
-      accountIndex
+      options?.accountIndex
     );
 
     // Initialize the wallet
     const wallet: Wallet = new Wallet();
     wallet.signer = new KeySigner(
       privateKey,
-      Secp256k1.compressPubkey(publicKey)
+      Secp256k1.compressPubkey(publicKey),
+      options?.addressPrefix
     );
 
     return wallet;
@@ -76,7 +83,12 @@ export class Wallet {
    * Generates a private key-based wallet
    * @param {string} privateKey the private key
    */
-  static fromPrivateKey = async (privateKey: Uint8Array): Promise<Wallet> => {
+  static fromPrivateKey = async (
+    privateKey: Uint8Array,
+    options?: {
+      addressPrefix?: string;
+    }
+  ): Promise<Wallet> => {
     // Derive the public key
     const { pubkey: publicKey } = await Secp256k1.makeKeypair(privateKey);
 
@@ -84,7 +96,8 @@ export class Wallet {
     const wallet: Wallet = new Wallet();
     wallet.signer = new KeySigner(
       privateKey,
-      Secp256k1.compressPubkey(publicKey)
+      Secp256k1.compressPubkey(publicKey),
+      options?.addressPrefix
     );
 
     return wallet;
@@ -97,13 +110,17 @@ export class Wallet {
    */
   static fromLedger = (
     connector: LedgerConnector,
-    accountIndex?: number
+    options?: {
+      accountIndex?: number;
+      addressPrefix?: string;
+    }
   ): Wallet => {
     const wallet: Wallet = new Wallet();
 
     wallet.signer = new LedgerSigner(
       connector,
-      accountIndex ? accountIndex : 0
+      options?.accountIndex ?? 0,
+      options?.addressPrefix
     );
 
     return wallet;


### PR DESCRIPTION
The prefix of the address is set to `g` only.
Because Adena may support other chains  in the future, we need the ability to set the prefix.

Please review the code I submitted and thank you in advance.