### PR TITLE
Fix account fetch ABCI query response

### DIFF
--- a/src/provider/types/abci.ts
+++ b/src/provider/types/abci.ts
@@ -36,7 +36,7 @@ export interface ABCIAccount {
     // the public key info
     public_key: {
       // type of public key
-      type: string;
+      '@type': string;
       // public key value
       value: string;
     } | null;


### PR DESCRIPTION
`auth/accounts/{address}` When I call the ABCI query on the path, the response seems to be in a different format.
It seems that the `type` of `public_key` is actually returned as `@type`.
