### PR TITLE
Change the return type of `sendTransaction`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnolang/tm2-js-client",
-  "version": "1.0.6",
+  "version": "1.1.0",
   "description": "Tendermint2 JS / TS Client",
   "main": "./bin/index.js",
   "repository": {

--- a/src/provider/jsonrpc/jsonrpc.test.ts
+++ b/src/provider/jsonrpc/jsonrpc.test.ts
@@ -15,7 +15,7 @@ import { newResponse, stringToBase64, uint8ArrayToBase64 } from '../utility';
 import { mock } from 'jest-mock-extended';
 import { Tx } from '../../proto';
 import { sha256 } from '@cosmjs/crypto';
-import { CommonEndpoint } from '../endpoints';
+import { CommonEndpoint, TransactionEndpoint } from '../endpoints';
 import { UnauthorizedErrorMessage } from '../errors/messages';
 import { TM2Error } from '../errors';
 
@@ -101,8 +101,9 @@ describe('JSON-RPC Provider', () => {
       try {
         // Create the provider
         const provider = new JSONRPCProvider(mockURL);
-        const tx = await provider.sendTransaction<BroadcastTxSyncResult>(
-          'encoded tx'
+        const tx = await provider.sendTransaction(
+          'encoded tx',
+          TransactionEndpoint.BROADCAST_TX_SYNC
         );
 
         expect(axios.post).toHaveBeenCalled();

--- a/src/provider/jsonrpc/jsonrpc.test.ts
+++ b/src/provider/jsonrpc/jsonrpc.test.ts
@@ -101,10 +101,12 @@ describe('JSON-RPC Provider', () => {
       try {
         // Create the provider
         const provider = new JSONRPCProvider(mockURL);
-        const hash = await provider.sendTransaction('encoded tx');
+        const tx = await provider.sendTransaction<BroadcastTxSyncResult>(
+          'encoded tx'
+        );
 
         expect(axios.post).toHaveBeenCalled();
-        expect(hash).toEqual(expectedHash);
+        expect(tx.hash).toEqual(expectedHash);
 
         if (expectedErr != '') {
           fail('expected error');

--- a/src/provider/provider.ts
+++ b/src/provider/provider.ts
@@ -1,7 +1,8 @@
 import {
   BlockInfo,
   BlockResult,
-  BroadcastType,
+  BroadcastAsGeneric,
+  BroadcastTransactionMap,
   ConsensusParams,
   NetworkInfo,
   Status,
@@ -93,17 +94,17 @@ export interface Provider {
   // Transaction specific methods //
 
   /**
-   * Sends the transaction to the node for committing.
+   * Sends the transaction to the node. If the type of endpoint
+   * is a broadcast commit, waits for the transaction to be committed to the chain.
    * The transaction needs to be signed beforehand.
-   * Returns the transaction hash
+   * Returns the transaction broadcast result.
    * @param {string} tx the base64-encoded signed transaction
-   * @param {BroadcastType} endpoint the transaction broadcast type (sync / commit).
-   * Defaults to broadcast_sync
+   * @param {BroadcastType} endpoint the transaction broadcast type (sync / commit)
    */
-  sendTransaction<BroadcastTransactionResult>(
+  sendTransaction<K extends keyof BroadcastTransactionMap>(
     tx: string,
-    endpoint?: BroadcastType
-  ): Promise<BroadcastTransactionResult>;
+    endpoint: K
+  ): Promise<BroadcastAsGeneric<K>['result']>;
 
   /**
    * Waits for the transaction to be committed on the chain.

--- a/src/provider/provider.ts
+++ b/src/provider/provider.ts
@@ -1,12 +1,12 @@
 import {
   BlockInfo,
   BlockResult,
+  BroadcastType,
   ConsensusParams,
   NetworkInfo,
   Status,
 } from './types';
 import { Tx } from '../proto';
-import { TransactionEndpoint } from './endpoints';
 
 /**
  * Read-only abstraction for accessing blockchain data
@@ -97,15 +97,13 @@ export interface Provider {
    * The transaction needs to be signed beforehand.
    * Returns the transaction hash
    * @param {string} tx the base64-encoded signed transaction
-   * @param {TransactionEndpoint} endpoint the transaction broadcast type (sync / commit).
+   * @param {BroadcastType} endpoint the transaction broadcast type (sync / commit).
    * Defaults to broadcast_sync
    */
-  sendTransaction(
+  sendTransaction<BroadcastTransactionResult>(
     tx: string,
-    endpoint?:
-      | TransactionEndpoint.BROADCAST_TX_SYNC
-      | TransactionEndpoint.BROADCAST_TX_COMMIT
-  ): Promise<string>;
+    endpoint?: BroadcastType
+  ): Promise<BroadcastTransactionResult>;
 
   /**
    * Waits for the transaction to be committed on the chain.

--- a/src/provider/types/common.ts
+++ b/src/provider/types/common.ts
@@ -280,6 +280,23 @@ export type BroadcastType =
   | TransactionEndpoint.BROADCAST_TX_SYNC
   | TransactionEndpoint.BROADCAST_TX_COMMIT;
 
-export type BroadcastTransactionResult =
-  | BroadcastTxSyncResult
-  | BroadcastTxCommitResult;
+export type BroadcastTransactionSync = {
+  endpoint: TransactionEndpoint.BROADCAST_TX_SYNC;
+  result: BroadcastTxSyncResult;
+};
+
+export type BroadcastTransactionCommit = {
+  endpoint: TransactionEndpoint.BROADCAST_TX_COMMIT;
+  result: BroadcastTxCommitResult;
+};
+
+export type BroadcastTransactionMap = {
+  [TransactionEndpoint.BROADCAST_TX_COMMIT]: BroadcastTransactionCommit;
+  [TransactionEndpoint.BROADCAST_TX_SYNC]: BroadcastTransactionSync;
+};
+
+export type BroadcastAsGeneric<
+  K extends keyof BroadcastTransactionMap = keyof BroadcastTransactionMap,
+> = {
+  [P in K]: BroadcastTransactionMap[P];
+}[K];

--- a/src/provider/types/common.ts
+++ b/src/provider/types/common.ts
@@ -1,4 +1,5 @@
 import { ABCIResponseBase } from './abci';
+import { TransactionEndpoint } from '../endpoints';
 
 export interface NetworkInfo {
   // flag indicating if networking is up
@@ -274,3 +275,11 @@ export interface BroadcastTxCommitResult {
   hash: string;
   height: string; // decimal number
 }
+
+export type BroadcastType =
+  | TransactionEndpoint.BROADCAST_TX_SYNC
+  | TransactionEndpoint.BROADCAST_TX_COMMIT;
+
+export type BroadcastTransactionResult =
+  | BroadcastTxSyncResult
+  | BroadcastTxCommitResult;

--- a/src/provider/websocket/ws.test.ts
+++ b/src/provider/websocket/ws.test.ts
@@ -16,7 +16,7 @@ import { WSProvider } from './ws';
 import WS from 'jest-websocket-mock';
 import { Tx } from '../../proto';
 import { sha256 } from '@cosmjs/crypto';
-import { CommonEndpoint } from '../endpoints';
+import { CommonEndpoint, TransactionEndpoint } from '../endpoints';
 import { UnauthorizedErrorMessage } from '../errors/messages';
 import { TM2Error } from '../errors';
 
@@ -278,9 +278,12 @@ describe('WS Provider', () => {
       await setHandler<BroadcastTxSyncResult>(response);
 
       try {
-        const hash = await wsProvider.sendTransaction('encoded tx');
+        const tx = await wsProvider.sendTransaction(
+          'encoded tx',
+          TransactionEndpoint.BROADCAST_TX_SYNC
+        );
 
-        expect(hash).toEqual(expectedHash);
+        expect(tx.hash).toEqual(expectedHash);
 
         if (expectedErr != '') {
           fail('expected error');

--- a/src/provider/websocket/ws.ts
+++ b/src/provider/websocket/ws.ts
@@ -5,6 +5,7 @@ import {
   BlockResult,
   BroadcastTxCommitResult,
   BroadcastTxSyncResult,
+  BroadcastType,
   ConsensusParams,
   NetworkInfo,
   RPCRequest,
@@ -257,12 +258,10 @@ export class WSProvider implements Provider {
     return this.parseResponse<Status>(response);
   }
 
-  async sendTransaction(
+  async sendTransaction<BroadcastTransactionResult>(
     tx: string,
-    endpoint?:
-      | TransactionEndpoint.BROADCAST_TX_SYNC
-      | TransactionEndpoint.BROADCAST_TX_COMMIT
-  ): Promise<string> {
+    endpoint?: BroadcastType
+  ): Promise<BroadcastTransactionResult> {
     const queryEndpoint = endpoint
       ? endpoint
       : TransactionEndpoint.BROADCAST_TX_SYNC;
@@ -270,12 +269,16 @@ export class WSProvider implements Provider {
     const request: RPCRequest = newRequest(queryEndpoint, [tx]);
 
     if (queryEndpoint == TransactionEndpoint.BROADCAST_TX_SYNC) {
-      return this.broadcastTxSync(request);
+      return (await this.broadcastTxSync(
+        request
+      )) as BroadcastTransactionResult;
     }
 
     // The endpoint is a commit broadcast
     // (it waits for the transaction to be committed) to the chain before returning
-    return this.broadcastTxCommit(request);
+    return (await this.broadcastTxCommit(
+      request
+    )) as BroadcastTransactionResult;
   }
 
   private async broadcastTxSync(request: RPCRequest): Promise<string> {

--- a/src/wallet/wallet.test.ts
+++ b/src/wallet/wallet.test.ts
@@ -1,4 +1,9 @@
-import { BroadcastTxSyncResult, JSONRPCProvider, Status } from '../provider';
+import {
+  BroadcastTxSyncResult,
+  JSONRPCProvider,
+  Status,
+  TransactionEndpoint,
+} from '../provider';
 import { mock } from 'jest-mock-extended';
 import { Wallet } from './wallet';
 import { EnglishMnemonic, Secp256k1 } from '@cosmjs/crypto';
@@ -247,8 +252,10 @@ describe('Wallet', () => {
     const wallet: Wallet = await Wallet.createRandom();
     wallet.connect(mockProvider);
 
-    const tx: BroadcastTxSyncResult =
-      await wallet.sendTransaction<BroadcastTxSyncResult>(mockTx);
+    const tx: BroadcastTxSyncResult = await wallet.sendTransaction(
+      mockTx,
+      TransactionEndpoint.BROADCAST_TX_SYNC
+    );
 
     expect(tx.hash).toBe(mockTxHash);
   });

--- a/src/wallet/wallet.test.ts
+++ b/src/wallet/wallet.test.ts
@@ -1,4 +1,4 @@
-import { JSONRPCProvider, Status } from '../provider';
+import { BroadcastTxSyncResult, JSONRPCProvider, Status } from '../provider';
 import { mock } from 'jest-mock-extended';
 import { Wallet } from './wallet';
 import { EnglishMnemonic, Secp256k1 } from '@cosmjs/crypto';
@@ -231,17 +231,25 @@ describe('Wallet', () => {
       network: 'testchain',
     };
 
+    const mockTransaction: BroadcastTxSyncResult = {
+      error: null,
+      data: null,
+      Log: '',
+      hash: mockTxHash,
+    };
+
     const mockProvider = mock<JSONRPCProvider>();
     mockProvider.getStatus.mockResolvedValue(mockStatus);
     mockProvider.getAccountNumber.mockResolvedValue(10);
     mockProvider.getAccountSequence.mockResolvedValue(10);
-    mockProvider.sendTransaction.mockResolvedValue(mockTxHash);
+    mockProvider.sendTransaction.mockResolvedValue(mockTransaction);
 
     const wallet: Wallet = await Wallet.createRandom();
     wallet.connect(mockProvider);
 
-    const txHash: string = await wallet.sendTransaction(mockTx);
+    const tx: BroadcastTxSyncResult =
+      await wallet.sendTransaction<BroadcastTxSyncResult>(mockTx);
 
-    expect(txHash).toBe(mockTxHash);
+    expect(tx.hash).toBe(mockTxHash);
   });
 });

--- a/src/wallet/wallet.ts
+++ b/src/wallet/wallet.ts
@@ -1,7 +1,7 @@
 import {
+  BroadcastType,
   Provider,
   Status,
-  TransactionEndpoint,
   uint8ArrayToBase64,
 } from '../provider';
 import { Signer } from './signer';
@@ -301,15 +301,13 @@ export class Wallet {
    * The transaction needs to be signed beforehand.
    * Returns the transaction hash (base-64)
    * @param {Tx} tx the signed transaction
-   * @param {TransactionEndpoint} endpoint the transaction broadcast type (sync / commit).
+   * @param {BroadcastType} endpoint the transaction broadcast type (sync / commit).
    * Defaults to broadcast_sync
    */
-  sendTransaction = async (
+  sendTransaction = async <BroadcastTransactionResult>(
     tx: Tx,
-    endpoint?:
-      | TransactionEndpoint.BROADCAST_TX_SYNC
-      | TransactionEndpoint.BROADCAST_TX_COMMIT
-  ): Promise<string> => {
+    endpoint?: BroadcastType
+  ): Promise<BroadcastTransactionResult> => {
     if (!this.provider) {
       throw new Error('provider not connected');
     }

--- a/src/wallet/wallet.ts
+++ b/src/wallet/wallet.ts
@@ -1,5 +1,5 @@
 import {
-  BroadcastType,
+  BroadcastTransactionMap,
   Provider,
   Status,
   uint8ArrayToBase64,
@@ -297,17 +297,17 @@ export class Wallet {
   };
 
   /**
-   * Encodes and sends the transaction.
+   * Encodes and sends the transaction. If the type of endpoint
+   * is a broadcast commit, waits for the transaction to be committed to the chain.
    * The transaction needs to be signed beforehand.
    * Returns the transaction hash (base-64)
    * @param {Tx} tx the signed transaction
-   * @param {BroadcastType} endpoint the transaction broadcast type (sync / commit).
-   * Defaults to broadcast_sync
+   * @param {BroadcastType} endpoint the transaction broadcast type (sync / commit)
    */
-  sendTransaction = async <BroadcastTransactionResult>(
+  async sendTransaction<K extends keyof BroadcastTransactionMap>(
     tx: Tx,
-    endpoint?: BroadcastType
-  ): Promise<BroadcastTransactionResult> => {
+    endpoint: K
+  ): Promise<BroadcastTransactionMap[K]['result']> {
     if (!this.provider) {
       throw new Error('provider not connected');
     }
@@ -317,7 +317,7 @@ export class Wallet {
 
     // Send the encoded transaction
     return this.provider.sendTransaction(encodedTx, endpoint);
-  };
+  }
 
   /**
    * Returns the associated signer


### PR DESCRIPTION
## Description

This PR changes the return type of `Provider` `sendTransaction` to return the transaction result it receives from the node.

The change was motivated to support return data from the transaction itself. As a result, this is propagated out to all method users, meaning the top level API will need to give users the support to send either a Sync or Commit transaction.