### PR TITLE
Switch WS request ID to `uuid` & bump WS connection timeout

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnolang/tm2-js-client",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Tendermint2 JS / TS Client",
   "main": "./bin/index.js",
   "repository": {
@@ -47,9 +47,11 @@
     "@cosmjs/amino": "^0.31.0",
     "@cosmjs/crypto": "^0.31.0",
     "@cosmjs/ledger-amino": "^0.31.0",
+    "@types/uuid": "^9.0.4",
     "axios": "^1.4.0",
     "long": "^5.2.3",
     "protobufjs": "^7.2.3",
+    "uuid": "^9.0.1",
     "ws": "^8.13.0"
   },
   "scripts": {

--- a/src/provider/utility/requests.utility.ts
+++ b/src/provider/utility/requests.utility.ts
@@ -1,4 +1,5 @@
 import { RPCError, RPCRequest, RPCResponse } from '../types';
+import { v4 as uuidv4 } from 'uuid';
 
 // The version of the supported JSON-RPC protocol
 const standardVersion = '2.0';
@@ -29,7 +30,7 @@ export const newResponse = <Result>(
   error?: RPCError
 ): RPCResponse<Result> => {
   return {
-    id: Date.now(),
+    id: uuidv4(),
     jsonrpc: standardVersion,
     result: result,
     error: error,

--- a/src/provider/websocket/ws.ts
+++ b/src/provider/websocket/ws.ts
@@ -128,8 +128,8 @@ export class WSProvider implements Provider {
    */
   waitForOpenConnection = (): Promise<null> => {
     return new Promise((resolve, reject) => {
-      const maxNumberOfAttempts = 10;
-      const intervalTime = 200; //ms
+      const maxNumberOfAttempts = 50;
+      const intervalTime = 200; // ms
 
       let currentAttempt = 0;
       const interval = setInterval(() => {
@@ -139,9 +139,9 @@ export class WSProvider implements Provider {
         }
 
         currentAttempt++;
-        if (currentAttempt > maxNumberOfAttempts - 1) {
+        if (currentAttempt >= maxNumberOfAttempts) {
           clearInterval(interval);
-          reject(new Error('Maximum number of attempts exceeded'));
+          reject(new Error('Unable to establish WS connection'));
         }
       }, intervalTime);
     });

--- a/src/provider/websocket/ws.ts
+++ b/src/provider/websocket/ws.ts
@@ -128,8 +128,8 @@ export class WSProvider implements Provider {
    */
   waitForOpenConnection = (): Promise<null> => {
     return new Promise((resolve, reject) => {
-      const maxNumberOfAttempts = 50;
-      const intervalTime = 200; // ms
+      const maxNumberOfAttempts = 20;
+      const intervalTime = 500; // ms
 
       let currentAttempt = 0;
       const interval = setInterval(() => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -928,6 +928,11 @@
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-2.0.1.tgz#20f18294f797f2209b5f65c8e3b5c8e8261d127c"
   integrity sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==
 
+"@types/uuid@^9.0.4":
+  version "9.0.4"
+  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-9.0.4.tgz#e884a59338da907bda8d2ed03e01c5c49d036f1c"
+  integrity sha512-zAuJWQflfx6dYJM62vna+Sn5aeSWhh3OB+wfUEACNcqUSc0AGc5JKl+ycL1vrH7frGTXhJchYjE1Hak8L819dA==
+
 "@types/ws@^8.5.4":
   version "8.5.5"
   resolved "https://registry.yarnpkg.com/@types/ws/-/ws-8.5.5.tgz#af587964aa06682702ee6dcbc7be41a80e4b28eb"
@@ -3471,6 +3476,11 @@ util-deprecate@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==
+
+uuid@^9.0.1:
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-9.0.1.tgz#e188d4c8853cc722220392c424cd637f32293f30"
+  integrity sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==
 
 v8-to-istanbul@^9.0.1:
   version "9.1.0"


### PR DESCRIPTION
## Description

Based on discussions in https://github.com/gnolang/gnochess/issues/86, this PR aims to integrate UUIDs for request IDs, as timestamps cannot be valid in highly concurrent environments.

Additionally, it also bumps the WS connection timeout from `2s` to `10s`, and modifies the error response to better reflect the encountered connection problem.