### PR TITLE
feat: Change the request ID to UUID

### DIFF
--- a/src/provider/utility/requests.utility.ts
+++ b/src/provider/utility/requests.utility.ts
@@ -13,7 +13,7 @@ export const newRequest = (method: string, params?: any[]): RPCRequest => {
   return {
     // the ID of the request is not that relevant for this helper method;
     // for finer ID control, instantiate the request object directly
-    id: Date.now(),
+    id: uuidv4(),
     jsonrpc: standardVersion,
     method: method,
     params: params,


### PR DESCRIPTION
I missed one in that PR. (https://github.com/gnolang/tm2-js-client/pull/85)
When creating the request, you need to put the UUID in the ID. (because the ID of the response object you receive from the server is the same as the request ID)

This is the part that causes the response to be lost for the same ID.
https://github.com/gnolang/tm2-js-client/blob/main/src/provider/websocket/ws.ts#L57-L63