### PR TITLE
Encode escape characters when generating transaction

### DIFF
--- a/src/wallet/utility/utility.ts
+++ b/src/wallet/utility/utility.ts
@@ -81,3 +81,15 @@ export const defaultAddressPrefix = 'g';
 export const stringToUTF8 = (str: string): Uint8Array => {
   return new TextEncoder().encode(str);
 };
+
+/**
+ * Escapes <,>,& in string.
+ * Golang's json marshaller escapes <,>,& by default.
+ * https://cs.opensource.google/go/go/+/refs/tags/go1.20.6:src/encoding/json/encode.go;l=46-53
+ */
+export function encodeCharacterSet(data: string) {
+  return data
+    .replace(/</g, '\\u003c')
+    .replace(/>/g, '\\u003e')
+    .replace(/&/g, '\\u0026');
+}

--- a/src/wallet/wallet.ts
+++ b/src/wallet/wallet.ts
@@ -8,7 +8,12 @@ import { Signer } from './signer';
 import { LedgerSigner } from './ledger';
 import { KeySigner } from './key';
 import { Secp256k1 } from '@cosmjs/crypto';
-import { generateEntropy, generateKeyPair, stringToUTF8 } from './utility';
+import {
+  encodeCharacterSet,
+  generateEntropy,
+  generateKeyPair,
+  stringToUTF8,
+} from './utility';
 import { LedgerConnector } from '@cosmjs/ledger-amino';
 import { entropyToMnemonic } from '@cosmjs/crypto/build/bip39';
 import { Any, PubKeySecp256k1, Tx, TxSignature } from '../proto';
@@ -271,7 +276,7 @@ export class Wallet {
     // a sorted JSON object, so the payload needs to be sorted
     // before signing
     const signBytes: Uint8Array = stringToUTF8(
-      sortedJsonStringify(signPayload)
+      encodeCharacterSet(sortedJsonStringify(signPayload))
     );
 
     // The public key needs to be encoded using protobuf for Amino


### PR DESCRIPTION
## Description

This PR adds a function to encode characters that are not JSON marshaled by GO when generating signature data.

The characters handled are `<`, `>`, `&`.

See the GO comment below.
https://cs.opensource.google/go/go/+/refs/tags/go1.20.13:src/encoding/json/encode.go;l=46-53