### PR TITLE
fix: Remove the time field from the tx signature payload

### DIFF
--- a/src/wallet/types/sign.ts
+++ b/src/wallet/types/sign.ts
@@ -27,8 +27,6 @@ export interface TxSignPayload {
   msgs: any[];
   // the transaction memo
   memo: string;
-  // signature generation time
-  time: string;
 }
 
 export const Secp256k1PubKeyType = '/tm.PubKeySecp256k1';

--- a/src/wallet/wallet.ts
+++ b/src/wallet/wallet.ts
@@ -254,10 +254,6 @@ export class Wallet {
       await this.provider.getAccountSequence(address);
     const publicKey: Uint8Array = await this.signer.getPublicKey();
 
-    // The timestamp for the signature needs to be set to "zero time"
-    // See https://github.com/gnolang/gno/issues/810
-    const defaultSigTimestamp = '0001-01-01T00:00:00Z';
-
     // Create the signature payload
     const signPayload: TxSignPayload = {
       chain_id: chainID,
@@ -269,7 +265,6 @@ export class Wallet {
       },
       msgs: decodeTxMessages(tx.messages), // unrolled message objects
       memo: tx.memo,
-      time: defaultSigTimestamp,
     };
 
     // The TM2 node does signature verification using


### PR DESCRIPTION
## Description

This PR is a change from https://github.com/gnolang/gno/pull/1939.

No longer handle the `time` field when signing off-chain.  

Remove the `time` field from the tx signature payload. 