### PR TITLE
Update README.md link

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ about account management.
 ## Documentation
 
 For the sake of keeping the README short and sweet, you can find the documentation and usage examples
-for the package [here](https://onbloc.gitbook.io/gnoland-developer-portal/docs/tm2-js-client).
+for the package [here](https://docs.gno.land/reference/tm2-js-client/).
 
 ## Acknowledgements
 


### PR DESCRIPTION
Now the documentation is in reference, not in docs. The link changed is the correct one.