### PR TITLE
feat: Add supporting for sponsor feature

### DIFF
--- a/src/wallet/wallet.ts
+++ b/src/wallet/wallet.ts
@@ -249,7 +249,18 @@ export class Wallet {
 
     // Extract the relevant account data
     const address: string = await this.getAddress();
-    const accountNumber: number = await this.provider.getAccountNumber(address);
+    // For case Sponsor Service will skip getAccountNumber if account not initialized
+    let accountNumber: number = 0;
+    if (tx.messages[0].typeUrl === '/vm.m_noop') {
+      try {
+        accountNumber = await this.provider.getAccountNumber(address);
+      } catch (e) {
+        // Skip getAccountNumber if account not initialized
+        accountNumber = 0;
+      }
+    } else {
+      accountNumber = await this.provider.getAccountNumber(address);
+    }
     const accountSequence: number =
       await this.provider.getAccountSequence(address);
     const publicKey: Uint8Array = await this.signer.getPublicKey();


### PR DESCRIPTION
As the introduction [here](https://hackmd.io/@thinhnx/B1rtb2NtR), the current version of `Adena-wallet` is using tm2-js-client to sign the transtactions / documents. This PR aims to support for signing with a `very newly created account` if this account is never made a transaction before.
This PR will check if the message type is `vm_noop` or not before throwing an errors.

Read more about sponsor-service at:
* Gno PRs: [#2630](https://github.com/gnolang/gno/pull/2630), [#2209](https://github.com/gnolang/gno/pull/2209)
* HackMD introduction [here](https://hackmd.io/@thinhnx/B1rtb2NtR)
* `updating...`