### PR TITLE
feat: add `getTransaction` method

### DIFF
--- a/src/provider/endpoints.ts
+++ b/src/provider/endpoints.ts
@@ -24,6 +24,7 @@ export enum TransactionEndpoint {
   BROADCAST_TX_ASYNC = 'broadcast_tx_async',
   BROADCAST_TX_SYNC = 'broadcast_tx_sync',
   BROADCAST_TX_COMMIT = 'broadcast_tx_commit',
+  TX = 'tx',
 }
 
 export enum ABCIEndpoint {

--- a/src/provider/jsonrpc/jsonrpc.ts
+++ b/src/provider/jsonrpc/jsonrpc.ts
@@ -11,6 +11,7 @@ import {
   NetworkInfo,
   RPCRequest,
   Status,
+  TxResult,
 } from '../types';
 import { RestService } from '../../services';
 import {
@@ -145,6 +146,12 @@ export class JSONRPCProvider implements Provider {
   async getStatus(): Promise<Status> {
     return await RestService.post<Status>(this.baseURL, {
       request: newRequest(CommonEndpoint.STATUS),
+    });
+  }
+
+  async getTransaction(hash: string): Promise<TxResult> {
+    return await RestService.post<TxResult>(this.baseURL, {
+      request: newRequest(TransactionEndpoint.TX, [hash]),
     });
   }
 

--- a/src/provider/types/common.ts
+++ b/src/provider/types/common.ts
@@ -233,6 +233,19 @@ export interface BlockResult {
   };
 }
 
+export interface TxResult {
+  // the transaction hash
+  hash: string;
+  // tx index in the block
+  index: number;
+  // the block height
+  height: string;
+  // deliver tx response
+  tx_result: DeliverTx;
+  // base64 encoded transaction
+  tx: string;
+}
+
 export interface DeliverTx {
   // the transaction ABCI response
   ResponseBase: ABCIResponseBase;

--- a/src/provider/websocket/ws.ts
+++ b/src/provider/websocket/ws.ts
@@ -12,6 +12,7 @@ import {
   RPCRequest,
   RPCResponse,
   Status,
+  TxResult,
 } from '../types';
 import {
   extractAccountNumberFromResponse,
@@ -257,6 +258,14 @@ export class WSProvider implements Provider {
     );
 
     return this.parseResponse<Status>(response);
+  }
+
+  async getTransaction(hash: string): Promise<TxResult> {
+    const response = await this.sendRequest<TxResult>(
+      newRequest(TransactionEndpoint.TX, [hash])
+    );
+
+    return this.parseResponse<TxResult>(response);
   }
 
   async sendTransaction<K extends keyof BroadcastTransactionMap>(


### PR DESCRIPTION
This PR implements support for the new `tx` endpoint, allowing users to find the transaction result by hash.

Reference: https://github.com/gnolang/gno/pull/1546