### PR TITLE
feat(provider): add `getAccount` method

### DIFF
--- a/src/provider/jsonrpc/jsonrpc.ts
+++ b/src/provider/jsonrpc/jsonrpc.ts
@@ -9,6 +9,7 @@ import {
 } from '../endpoints';
 import { Provider } from '../provider';
 import {
+  ABCIAccount,
   ABCIErrorKey,
   ABCIResponse,
   BlockInfo,
@@ -23,6 +24,7 @@ import {
   TxResult,
 } from '../types';
 import {
+  extractAccountFromResponse,
   extractAccountNumberFromResponse,
   extractBalanceFromResponse,
   extractSequenceFromResponse,
@@ -156,6 +158,24 @@ export class JSONRPCProvider implements Provider {
     );
 
     return extractAccountNumberFromResponse(
+      abciResponse.response.ResponseBase.Data
+    );
+  }
+
+  async getAccount(address: string, height?: number): Promise<ABCIAccount> {
+    const abciResponse: ABCIResponse = await RestService.post<ABCIResponse>(
+      this.baseURL,
+      {
+        request: newRequest(ABCIEndpoint.ABCI_QUERY, [
+          `auth/accounts/${address}`,
+          '',
+          '0', // Height; not supported > 0 for now
+          false,
+        ]),
+      }
+    );
+
+    return extractAccountFromResponse(
       abciResponse.response.ResponseBase.Data
     );
   }

--- a/src/provider/provider.ts
+++ b/src/provider/provider.ts
@@ -33,8 +33,8 @@ export interface Provider {
    * Fetches the account sequence
    * @param {string} address the bech32 address of the account
    * @param {number} [height=0] the height for querying.
-   * @deprecated use {@link getAccount}
    * If omitted, the latest height is used.
+   * @deprecated use {@link getAccount} instead
    */
   getAccountSequence(address: string, height?: number): Promise<number>;
 
@@ -43,8 +43,8 @@ export interface Provider {
    * is not initialized
    * @param {string} address the bech32 address of the account
    * @param {number} [height=0] the height for querying.
-   * @deprecated use {@link getAccount}
    * If omitted, the latest height is used
+   * @deprecated use {@link getAccount} instead
    */
   getAccountNumber(address: string, height?: number): Promise<number>;
 

--- a/src/provider/provider.ts
+++ b/src/provider/provider.ts
@@ -1,4 +1,5 @@
 import {
+  ABCIAccount,
   BlockInfo,
   BlockResult,
   BroadcastAsGeneric,
@@ -32,6 +33,7 @@ export interface Provider {
    * Fetches the account sequence
    * @param {string} address the bech32 address of the account
    * @param {number} [height=0] the height for querying.
+   * @deprecated use {@link getAccount}
    * If omitted, the latest height is used.
    */
   getAccountSequence(address: string, height?: number): Promise<number>;
@@ -41,9 +43,19 @@ export interface Provider {
    * is not initialized
    * @param {string} address the bech32 address of the account
    * @param {number} [height=0] the height for querying.
+   * @deprecated use {@link getAccount}
    * If omitted, the latest height is used
    */
   getAccountNumber(address: string, height?: number): Promise<number>;
+
+  /**
+   * Fetches the account. Errors out if the account
+   * is not initialized
+   * @param {string} address the bech32 address of the account
+   * @param {number} [height=0] the height for querying.
+   * If omitted, the latest height is used
+   */
+  getAccount(address: string, height?: number): Promise<ABCIAccount>;
 
   /**
    * Fetches the block at the specific height, if any

--- a/src/provider/utility/provider.utility.ts
+++ b/src/provider/utility/provider.utility.ts
@@ -97,6 +97,28 @@ export const extractAccountNumberFromResponse = (
 };
 
 /**
+ * Extracts the account from the ABCI response
+ * @param {string | null} abciData the base64-encoded ABCI data
+ */
+export const extractAccountFromResponse = (
+  abciData: string | null
+): ABCIAccount => {
+  // Make sure the response is initialized
+  if (!abciData) {
+    throw new Error('account is not initialized');
+  }
+
+  try {
+    // Parse the account
+    const account: ABCIAccount = parseABCI<ABCIAccount>(abciData);
+
+    return account
+  } catch (e) {
+    throw new Error('account is not initialized');
+  }
+};
+
+/**
  * Extracts the simulate transaction response from the ABCI response value
  * @param {string | null} abciData the base64-encoded ResponseDeliverTx proto message
  */

--- a/src/provider/websocket/ws.test.ts
+++ b/src/provider/websocket/ws.test.ts
@@ -260,6 +260,39 @@ describe('WS Provider', () => {
     });
   });
 
+    describe('getAccount', () => {
+    const validAccount: ABCIAccount = {
+      BaseAccount: {
+        address: 'random address',
+        coins: '',
+        public_key: null,
+        account_number: '10',
+        sequence: '0',
+      },
+    };
+
+    test.each([
+      [
+        JSON.stringify(validAccount),
+        validAccount,
+      ], // account exists
+      ['null', null], // account doesn't exist
+    ])('case %#', async (response, expected) => {
+      const mockResponse: ABCIResponse = mockABCIResponse(response);
+
+      // Set the response
+      await setHandler<ABCIResponse>(mockResponse);
+
+      try {
+        const account: ABCIAccount =
+          await wsProvider.getAccount('address');
+        expect(account).toStrictEqual(expected);
+      } catch (e) {
+        expect((e as Error).message).toContain('account is not initialized');
+      }
+    });
+  });
+
   describe('getBalance', () => {
     const denomination = 'atom';
     test.each([

--- a/src/provider/websocket/ws.ts
+++ b/src/provider/websocket/ws.ts
@@ -8,6 +8,7 @@ import {
 } from '../endpoints';
 import { Provider } from '../provider';
 import {
+  ABCIAccount,
   ABCIErrorKey,
   ABCIResponse,
   BlockInfo,
@@ -23,6 +24,7 @@ import {
   TxResult,
 } from '../types';
 import {
+  extractAccountFromResponse,
   extractAccountNumberFromResponse,
   extractBalanceFromResponse,
   extractSequenceFromResponse,
@@ -270,6 +272,24 @@ export class WSProvider implements Provider {
     const abciResponse = this.parseResponse<ABCIResponse>(response);
 
     return extractAccountNumberFromResponse(
+      abciResponse.response.ResponseBase.Data
+    );
+  }
+
+  async getAccount(address: string, height?: number): Promise<ABCIAccount> {
+    const response = await this.sendRequest<ABCIResponse>(
+      newRequest(ABCIEndpoint.ABCI_QUERY, [
+        `auth/accounts/${address}`,
+        '',
+        '0', // Height; not supported > 0 for now
+        false,
+      ])
+    );
+
+    // Parse the response
+    const abciResponse = this.parseResponse<ABCIResponse>(response);
+
+    return extractAccountFromResponse(
       abciResponse.response.ResponseBase.Data
     );
   }


### PR DESCRIPTION
- Add a `getAccount` method to the provider interface that returns the full `ABCIAccount`
- Implement `getAccount` in jsonrpc and websocket providers
- Mark `getAccountSequence` and `getAccountNumber` as deprecated