### PR TITLE
fix: pass heightGte param to status call

### DIFF
--- a/src/provider/jsonrpc/jsonrpc.ts
+++ b/src/provider/jsonrpc/jsonrpc.ts
@@ -180,7 +180,7 @@ export class JSONRPCProvider implements Provider {
 
   async getStatus(): Promise<Status> {
     return await RestService.post<Status>(this.baseURL, {
-      request: newRequest(CommonEndpoint.STATUS),
+      request: newRequest(CommonEndpoint.STATUS, [null]),
     });
   }
 

--- a/src/provider/websocket/ws.ts
+++ b/src/provider/websocket/ws.ts
@@ -294,7 +294,7 @@ export class WSProvider implements Provider {
 
   async getStatus(): Promise<Status> {
     const response = await this.sendRequest<Status>(
-      newRequest(CommonEndpoint.STATUS)
+      newRequest(CommonEndpoint.STATUS, [null])
     );
 
     return this.parseResponse<Status>(response);


### PR DESCRIPTION
Since https://github.com/gnolang/gno/pull/4692 was merged on gno core, the status call of this lib is broken since it doesn't pass the correct number of arguments.

This prevents signing transactions since it uses status.