### PR TITLE
fix: make the repo installable as a git dependency on pnpm 9

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,13 @@
+# Empty on purpose: this repo is a single package, not a workspace. The file
+# exists only to carry the settings below.
+#
+# pnpm 9 refuses to run at all if a pnpm-workspace.yaml has no `packages`
+# key ("ERROR packages field missing or empty"), which makes the repo
+# uninstallable as a git dependency for anyone still on pnpm 9 — pnpm builds
+# a git dependency by running `pnpm install` inside it, and that install is
+# what fails. pnpm 10 is unaffected either way.
+packages: []
+
 allowBuilds:
   esbuild: true
   protobufjs: true


### PR DESCRIPTION
Fixes #280.

`pnpm-workspace.yaml` carries build settings but has no `packages` key. pnpm 10 accepts that; **pnpm 9 refuses to run at all** with `ERROR packages field missing or empty`.

That breaks consumers rather than this repo: pnpm builds a git dependency by running `pnpm install` inside the cloned repo, so on pnpm 9 `pnpm add github:gnolang/tm2-js-client#<ref>` fails with `ERR_PNPM_PREPARE_PACKAGE` before the build starts — which rules out trying an unreleased fix or reviewing a PR against a real consumer.

`packages: []` states what is already true: a single package, not a workspace. The comment explains why the file exists with an empty list, so nobody "tidies" it away.

### Verified both directions

|  | pnpm 9.15.0 | pnpm 10.33.0 |
|---|---|---|
| `pnpm install` in-repo, before | ❌ | ✅ |
| `pnpm install` in-repo, after | ✅ install + `prepare` build | ✅ install + `prepare` build |
| `pnpm add github:…#<ref>`, before | ❌ `ERR_PNPM_PREPARE_PACKAGE` | ✅ |
| `pnpm add github:…#<ref>`, after | ✅ installs, imports resolve | ✅ |

Checked against the `packageManager` version pinned here, not just the older one — this shouldn't change anything for the existing toolchain.

Installed from this branch on pnpm 9 into a scratch project and confirmed the package imports and its exports resolve.
